### PR TITLE
Allow custom TextEditingController

### DIFF
--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -18,6 +18,10 @@ class DashChat extends StatefulWidget {
   /// Takes a [List] of [ChatMessage]
   final List<ChatMessage> messages;
 
+  /// If provided, this text editing controller will be used for
+  /// the text input.
+  final TextEditingController textController;
+
   /// If provided will stop using the default controller
   /// i.e [TextEditingController] and will use this to update the
   /// text input field.
@@ -245,6 +249,7 @@ class DashChat extends StatefulWidget {
     @required this.messages,
     this.onTextChange,
     this.text,
+    this.textController,
     this.inputDecoration,
     this.textCapitalization = TextCapitalization.none,
     this.alwaysShowSend = false,
@@ -282,8 +287,8 @@ class DashChat extends StatefulWidget {
 }
 
 class DashChatState extends State<DashChat> {
-  final TextEditingController _controller = TextEditingController();
   final FocusNode inputFocusNode = FocusNode();
+  TextEditingController textController;
   ScrollController scrollController;
   String _text = "";
   bool visible = false;
@@ -344,6 +349,7 @@ class DashChatState extends State<DashChat> {
   @override
   void initState() {
     scrollController = widget.scrollController ?? ScrollController();
+    textController = widget.textController ?? TextEditingController();
 
     Timer(Duration(milliseconds: 500), () {
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
@@ -475,7 +481,7 @@ class DashChatState extends State<DashChat> {
               inputToolbarMargin: widget.inputToolbarMargin,
               showTraillingBeforeSend: widget.showTraillingBeforeSend,
               inputMaxLines: widget.inputMaxLines,
-              controller: _controller,
+              controller: textController,
               inputDecoration: widget.inputDecoration,
               textCapitalization: widget.textCapitalization,
               onSend: widget.onSend,


### PR DESCRIPTION
I was attempting to add speech to text for the text input, but there was no way to customize the TextEditingController that the ChatToolbarInput was using so I couldn't fill out the TextField with my own data.

The "text" property didn't seem to affect the text editing controller and was not being fed in. So instead of that, I just added a new property where someone could pass in their own TextEditingController that is passed off to the TextField (creating an internal one if that is not needed - similar to the ScrollController).