### PR TITLE
If inverted is true, we don't need to scroll initially.

### DIFF
--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -352,7 +352,8 @@ class DashChatState extends State<DashChat> {
     textController = widget.textController ?? TextEditingController();
 
     Timer(Duration(milliseconds: 500), () {
-      scrollController.jumpTo(scrollController.position.maxScrollExtent);
+      double initPos = widget.inverted ? 0.0 : scrollController.position.maxScrollExtent;
+      scrollController.jumpTo(initPos);
 
       scrollController.addListener(() {
         if (widget.shouldShowLoadEarlier) {


### PR DESCRIPTION
If inverted is set to true, the scroll controller scrolls to the "top" of the list which is now the older messages.

When using inverted the scroll technically starts at the latest (as the most recent are already visible).