### PR TITLE
'vedio' to 'video', null handling for quick replies + two minor things

### DIFF
--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -98,8 +98,6 @@ class _MessageListViewState extends State<MessageListView> {
   Widget build(BuildContext context) {
     DateTime currentDate;
 
-    print(widget.dateFormat != null);
-
     return Flexible(
       child: GestureDetector(
         onTap: () => FocusScope.of(context).requestFocus(FocusNode()),

--- a/lib/src/models/chat_message.dart
+++ b/lib/src/models/chat_message.dart
@@ -73,9 +73,11 @@ class ChatMessage {
       data['video'] = this.video;
       data['createdAt'] = this.createdAt.millisecondsSinceEpoch;
       data['user'] = user.toJson();
-      data['quickReplies'] = quickReplies.toJson();
-    } catch (e) {
+      data['quickReplies'] = quickReplies?.toJson();
+    } catch (e, stack) {
+      print('ERROR caught when trying to convert ChatMessage to JSON:');
       print(e);
+      print(stack);
     }
     return data;
   }

--- a/lib/src/models/chat_message.dart
+++ b/lib/src/models/chat_message.dart
@@ -27,7 +27,7 @@ class ChatMessage {
 
   /// A [non-optional] parameter which is used to display vedio
   /// takes a [Sring] as a url
-  String vedio;
+  String video;
 
   /// A [non-optional] parameter which is used to show quick replies
   /// to the user
@@ -38,7 +38,7 @@ class ChatMessage {
     @required this.text,
     @required this.user,
     this.image,
-    this.vedio,
+    this.video,
     this.quickReplies,
     String Function() messageIdGenerator,
     DateTime createdAt,
@@ -55,7 +55,7 @@ class ChatMessage {
     id = json['id'];
     text = json['text'];
     image = json['image'];
-    vedio = json['vedio'];
+    video = json['video'] ?? json['vedio'];
     createdAt = DateTime.fromMillisecondsSinceEpoch(json['createdAt']);
     user = ChatUser.fromJson(json['user']);
     quickReplies = json['quickReplies'] != null
@@ -70,7 +70,7 @@ class ChatMessage {
       data['id'] = this.id;
       data['text'] = this.text;
       data['image'] = this.image;
-      data['vedio'] = this.vedio;
+      data['video'] = this.video;
       data['createdAt'] = this.createdAt.millisecondsSinceEpoch;
       data['user'] = user.toJson();
       data['quickReplies'] = quickReplies.toJson();


### PR DESCRIPTION
I've renamed `vedio` field of ChatMessage to `video` (assumed it was a typo). I left fallback for reading the `vedio` field from JSON, so it should be compatibile with previous versions of the package. I also had some problems with `null` values when I added no quick replies to the message, so they are now parsed to JSON with `.?`.

I also changed two minor things: I removed print checking if date format is not null (It flooded my console with `true`s) and added stack trace and the message identifying where something went wrong to the try-catch on convering ChatMessage to JSON.

So, as you can see, they're rather quality-of-life improvements than anything else, but I hope it'll be useful.