### PR TITLE
Change the avatar boxfit value

### DIFF
--- a/lib/src/widgets/avatar_container.dart
+++ b/lib/src/widgets/avatar_container.dart
@@ -59,7 +59,7 @@ class AvatarContainer extends StatelessWidget {
                           child: FadeInImage.memoryNetwork(
                             image: user.avatar,
                             placeholder: kTransparentImage,
-                            fit: BoxFit.contain,
+                            fit: BoxFit.cover,
                             height: constraints.maxWidth * 0.08,
                             width: constraints.maxWidth * 0.08,
                           ),


### PR DESCRIPTION
Using `BoxFit.cover` instead of `BoxFit.contain` makes more sense for an avatar image, we don't want to see the grey circle under the image even if the image is not square.

Before:

![Capture d’écran 2020-04-21 à 22 21 44](https://user-images.githubusercontent.com/18089010/79910176-82689a00-841e-11ea-90b8-7483efa1b54e.png)

Now: 

![Capture d’écran 2020-04-21 à 22 20 23](https://user-images.githubusercontent.com/18089010/79910111-62d17180-841e-11ea-936c-a2e423ea335b.png)
