### PR TITLE
use opacity to have invisible avatars instead of a sized box

### DIFF
--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -189,22 +189,20 @@ class _MessageListViewState extends State<MessageListView> {
                                   padding: EdgeInsets.symmetric(
                                     horizontal: constraints.maxWidth * 0.02,
                                   ),
-                                  child: ((widget.showAvatarForEverMessage ||
-                                              showAvatar) &&
-                                          widget.messages[i].user.uid !=
-                                              widget.user.uid)
-                                      ? AvatarContainer(
-                                          user: widget.messages[i].user,
-                                          onPress: widget.onPressAvatar,
-                                          onLongPress: widget.onLongPressAvatar,
-                                          avatarBuilder: widget.avatarBuilder,
-                                        )
-                                      : SizedBox(
-                                          width: widget.messages[i].user.uid !=
-                                                  widget.user.uid
-                                              ? constraints.maxWidth * 0.08
-                                              : 0.0,
-                                        ),
+                                  child: Opacity(
+                                    opacity: (widget.showAvatarForEverMessage ||
+                                                showAvatar) &&
+                                            widget.messages[i].user.uid !=
+                                                widget.user.uid
+                                        ? 1
+                                        : 0,
+                                    child: AvatarContainer(
+                                      user: widget.messages[i].user,
+                                      onPress: widget.onPressAvatar,
+                                      onLongPress: widget.onLongPressAvatar,
+                                      avatarBuilder: widget.avatarBuilder,
+                                    ),
+                                  ),
                                 ),
                                 Expanded(
                                   child: GestureDetector(
@@ -280,24 +278,21 @@ class _MessageListViewState extends State<MessageListView> {
                                     padding: EdgeInsets.symmetric(
                                       horizontal: constraints.maxWidth * 0.02,
                                     ),
-                                    child: ((widget.showAvatarForEverMessage ||
-                                                showAvatar) &&
-                                            widget.messages[i].user.uid ==
-                                                widget.user.uid)
-                                        ? AvatarContainer(
-                                            user: widget.messages[i].user,
-                                            onPress: widget.onPressAvatar,
-                                            onLongPress:
-                                                widget.onLongPressAvatar,
-                                            avatarBuilder: widget.avatarBuilder,
-                                          )
-                                        : SizedBox(
-                                            width: widget
-                                                        .messages[i].user.uid ==
-                                                    widget.user.uid
-                                                ? constraints.maxWidth * 0.08
-                                                : 0.0,
-                                          ),
+                                    child: Opacity(
+                                      opacity:
+                                          (widget.showAvatarForEverMessage ||
+                                                      showAvatar) &&
+                                                  widget.messages[i].user.uid ==
+                                                      widget.user.uid
+                                              ? 1
+                                              : 0,
+                                      child: AvatarContainer(
+                                        user: widget.messages[i].user,
+                                        onPress: widget.onPressAvatar,
+                                        onLongPress: widget.onLongPressAvatar,
+                                        avatarBuilder: widget.avatarBuilder,
+                                      ),
+                                    ),
                                   )
                                 else
                                   SizedBox(


### PR DESCRIPTION
By using Opacity widget we can make sure that the padding on left or right of the message (according to the owner of the message) will always be at the same size as the avatar even if a custom avatar is provided (with avatar builder property).

It also allows to fix #42 and fix #36. To never show Avatars we can simply give an empty Container and there will be no padding issues.