### PR TITLE
Fix issue when instantiating a ChatUser with name property.

### DIFF
--- a/lib/src/models/chat_user.dart
+++ b/lib/src/models/chat_user.dart
@@ -39,7 +39,7 @@ class ChatUser {
     this.firstName,
     this.lastName,
   }) {
-    this.name = this.name == null ? "$firstName $lastName" : name;
+    this.name = name == null ? "$firstName $lastName" : name;
     this.uid = uid != null ? uid : Uuid().v4().toString();
   }
 

--- a/test/chat_user_test.dart
+++ b/test/chat_user_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dash_chat/dash_chat.dart';
+
+void main() {
+  test('can instantiate a ChatUser passing a name', () {
+    ChatUser chatUser = ChatUser(
+      name: 'my-name',
+    );
+
+    expect(chatUser.name, 'my-name');
+  });
+
+  test('can instantiate a ChatUser passing a first and last name', () {
+    ChatUser chatUser = ChatUser(
+      firstName: 'first',
+      lastName: 'last',
+    );
+
+    expect(chatUser.name, 'first last');
+  });
+}


### PR DESCRIPTION
After the addition of `first` and `last` name attributes the `name` attribute stopped working and it was evaluated to `null null`.

This PR fixes the issues and adds unit tests covering this scenario. 