### PR TITLE
added feature for messageDecorationBuilder with example in ReadMe !

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ ChatMessage(
 - `quickReplyScroll` (bool) - Should the quick reply options be horizontally scrollable
 - `quickReplyPadding` (EdgeInsetsGeometry) - Padding for QuickReply
 - `inputDisabled` (bool) - Should the input TextField be disabled, defaults to `false`
+- `messageDecorationBuilder` (BoxDecoration Function(ChatMessage, isUser) - Override the message container decoration. [Note: This will override the messageContainerDecoration ]
+
+  ```dart
+  DashChat(
+    ...
+    messageDecorationBuilder: (ChatMessage msg, bool isUser){
+      return BoxDecoration(
+        ...
+        color: isUser ? Colors.red : Colors.blue, // example
+        ...
+      );
+    },
+    ...
+  );
+  ```
 
 ## Credits 👨🏻‍💻
 

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -267,6 +267,12 @@ class DashChat extends StatefulWidget {
   /// Defaults to `30.0`
   final double avatarMaxSize;
 
+  /// overrides the boxdecoration of the message
+  /// can be used to override color, or customise the message container
+  /// params [ChatMessage] and [isUser]: boolean
+  /// return BoxDecoration
+  final BoxDecoration Function(ChatMessage, bool) messageDecorationBuilder;
+
   ScrollToBottomStyle scrollToBottomStyle;
 
   DashChat({
@@ -344,6 +350,7 @@ class DashChat extends StatefulWidget {
     this.messageButtonsBuilder,
     this.messagePadding = const EdgeInsets.all(8.0),
     this.textBeforeImage = true,
+    this.messageDecorationBuilder,
   }) : super(key: key) {
     this.scrollToBottomStyle = scrollToBottomStyle ?? new ScrollToBottomStyle();
   }
@@ -499,6 +506,7 @@ class DashChatState extends State<DashChat> {
                     visible: visible,
                     showLoadMore: showLoadMore,
                     messageButtonsBuilder: widget.messageButtonsBuilder,
+                    messageDecorationBuilder: widget.messageDecorationBuilder
                   ),
                   if (widget.messages.length != 0 &&
                       widget.messages.last.user.uid != widget.user.uid &&

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -35,6 +35,7 @@ class MessageListView extends StatefulWidget {
   final EdgeInsets messagePadding;
   final bool textBeforeImage;
   final double avatarMaxSize;
+  final BoxDecoration Function(ChatMessage, bool) messageDecorationBuilder;
 
   MessageListView(
       {this.showLoadEarlierWidget,
@@ -71,7 +72,9 @@ class MessageListView extends StatefulWidget {
       this.showLoadMore,
       this.messageButtonsBuilder,
       this.messagePadding = const EdgeInsets.all(8.0),
-      this.textBeforeImage = true});
+      this.textBeforeImage = true,
+      this.messageDecorationBuilder,
+      });
 
   @override
   _MessageListViewState createState() => _MessageListViewState();
@@ -284,6 +287,8 @@ class _MessageListViewState extends State<MessageListView> {
                                                   widget.messageButtonsBuilder,
                                               textBeforeImage:
                                                   widget.textBeforeImage,
+                                              messageDecorationBuilder:
+                                                  widget.messageDecorationBuilder,
                                             ),
                                           ),
                                   ),

--- a/lib/src/widgets/message_container.dart
+++ b/lib/src/widgets/message_container.dart
@@ -61,6 +61,12 @@ class MessageContainer extends StatelessWidget {
   /// Default to `true`
   final bool textBeforeImage;
 
+  /// overrides the boxdecoration of the message
+  /// can be used to override color, or customise the message container
+  /// params [ChatMessage] and [isUser]: boolean
+  /// return BoxDecoration
+  final BoxDecoration Function(ChatMessage, bool) messageDecorationBuilder;
+
   const MessageContainer({
     @required this.message,
     @required this.timeFormat,
@@ -75,6 +81,7 @@ class MessageContainer extends StatelessWidget {
     this.messageButtonsBuilder,
     this.buttons,
     this.messagePadding = const EdgeInsets.all(8.0),
+    this.messageDecorationBuilder,
   });
 
   @override
@@ -88,20 +95,22 @@ class MessageContainer extends StatelessWidget {
         maxWidth: constraints.maxWidth * 0.8,
       ),
       child: Container(
-        decoration: messageContainerDecoration != null
-            ? messageContainerDecoration.copyWith(
-                color: message.user.containerColor != null
-                    ? message.user.containerColor
-                    : messageContainerDecoration.color,
-              )
-            : BoxDecoration(
-                color: message.user.containerColor != null
-                    ? message.user.containerColor
-                    : isUser
-                        ? Theme.of(context).accentColor
-                        : Color.fromRGBO(225, 225, 225, 1),
-                borderRadius: BorderRadius.circular(5.0),
-              ),
+        decoration: messageDecorationBuilder != null
+            ? messageDecorationBuilder(message, isUser)
+            : messageContainerDecoration != null
+                ? messageContainerDecoration.copyWith(
+                    color: message.user.containerColor != null
+                        ? message.user.containerColor
+                        : messageContainerDecoration.color,
+                  )
+                : BoxDecoration(
+                    color: message.user.containerColor != null
+                        ? message.user.containerColor
+                        : isUser
+                            ? Theme.of(context).accentColor
+                            : Color.fromRGBO(225, 225, 225, 1),
+                    borderRadius: BorderRadius.circular(5.0),
+                  ),
         margin: EdgeInsets.only(
           bottom: 5.0,
         ),


### PR DESCRIPTION
solves the https://github.com/fayeed/dash_chat/issues/85 [https://github.com/fayeed/dash_chat/issues/85](#85 )
- Added messageDecorationBuilder which can be used to override the BoxDecoration of message container.
[Note it will override the values provided in messageContainerDecoration )